### PR TITLE
Check if member expr's first member is a call expr

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ export default function ({ types: t }) {
           id = object;
         }
 
-        if (id.callee) {
+        if (t.isCallExpression(id)) {
           if (id.callee.name === 'require') {
             return;
           }


### PR DESCRIPTION
Since the presence of a `callee` prop doesn't necessarily mean it's a call expression. Could as well be a [BindExpression (experimental)](https://github.com/babel/babel/blob/7.0/packages/babel-types/src/definitions/experimental.js#L14) or something completely new someone adds tomorrow 😉