### PR TITLE
Use babel declare helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   ],
   "homepage": "https://github.com/amilajack/babel-plugin-fail-explicit#readme",
   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.0.0",
     "safe-access-check": "^0.0.15"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,6 +68,11 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
+"@babel/helper-plugin-utils@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
+  integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
+
 "@babel/helper-split-export-declaration@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "http://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz#c0b351735e0fbcb3822c8ad8db4e583b05ebd9dc"


### PR DESCRIPTION
See more about it [on the docs](https://babeljs.io/docs/en/babel-helper-plugin-utils#what-this-does).

- Options will always be accessible as a parameter (although there are no options at the moment)
- `assertVersion` will always exist (although it isn't needed right now since this plugin seems to support both babel 6 and 7).
